### PR TITLE
handle additional cases where rules were getting dropped

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -254,6 +254,24 @@
 	<h2 class="my-2 text-3xl">Layout</h2>
 
 	<div class="my-4">
+		<div class="drawer">
+			<input id="my-drawer" type="checkbox" class="drawer-toggle" />
+			<div class="drawer-content">
+				<!-- Page content here -->
+				<label for="my-drawer" class="btn btn-primary drawer-button">Open drawer</label>
+			</div>
+			<div class="drawer-side">
+				<label for="my-drawer" aria-label="close sidebar" class="drawer-overlay"></label>
+				<ul class="menu bg-base-200 text-base-content min-h-full w-80 p-4">
+					<!-- Sidebar content here -->
+					<li><a>Sidebar Item 1</a></li>
+					<li><a>Sidebar Item 2</a></li>
+				</ul>
+			</div>
+		</div>
+	</div>
+
+	<div class="my-4">
 		<h3 class="font-bold my-1 text-xl">Mask</h3>
 		<img
 			class="mask mask-squircle"
@@ -334,11 +352,23 @@
 	</div>
 
 	<div class="my-4">
-		<h3 class="font-bold my-1 text-xl">Tab</h3>
-		<div class="tabs">
-			<a class="tab tab-bordered">Tab 1</a>
-			<a class="tab tab-bordered tab-active">Tab 2</a>
-			<a class="tab tab-bordered">Tab 3</a>
+		<h3 class="font-bold my-1 text-xl">Tabs (links)</h3>
+		<div class="tabs tabs-bordered">
+			<a class="tab">Tab 1</a>
+			<a class="tab tab-active">Tab 2</a>
+			<a class="tab">Tab 3</a>
+		</div>
+	</div>
+
+	<div class="my-4">
+		<h3 class="font-bold my-1 text-xl">Tabs (input)</h3>
+		<div class="tabs tabs-bordered w-full">
+			<input type="radio" name="tabs-input-demo" role="tab" class="tab" aria-label="Tab 1" />
+			<div role="tabpanel" class="tab-content p-10">Tab 1 Content</div>
+			<input type="radio" name="tabs-input-demo" role="tab" class="tab" aria-label="Tab 2" checked />
+			<div role="tabpanel" class="tab-content p-10">Tab 2 Content</div>
+			<input type="radio" name="tabs-input-demo" role="tab" class="tab" aria-label="Tab 3" />
+			<div role="tabpanel" class="tab-content p-10">Tab 3 Content</div>
 		</div>
 	</div>
 

--- a/index.ts
+++ b/index.ts
@@ -93,7 +93,6 @@ export const presetDaisy = (
 				// Skip prefixes
 				: (tokens[2] as ClassToken).name
 		} else if (token.type === 'type') {
-			console.log(tokens);
 			// default base to what is likely most specific class by finding the last one in the list
 			// input.tab:checked + .tab-content, :is(.tab-active, [aria-selected="true"]) + .tab-content -> .tab-content
 			for (var i = tokens.length - 1; i >= 0; i--) {
@@ -111,7 +110,6 @@ export const presetDaisy = (
 
 					if(hasToken.argument) {
 						base = (tokenize(hasToken.argument!)[0] as ClassToken).name;
-						console.log(base);
 					}
 				}
 			}


### PR DESCRIPTION
First off, thanks for keeping this preset updated and publishing to npm!

I've been using this in a project and was having difficulty when trying to use tabs where the input element could control showing/hiding the active content.  After digging into this, there are some rules/styles from daisy that seem to be slipping through the cracks as they have a token type of 'type' and resulted in a base defined as an empty string, so they would not get matched by unocss.

The proposed fix is to check for this case and try to define a reasonable base to use, which the implementation finds by scanning the selector for the last class, with the assumption that is the most specific.  The specific case I was running into was for the following:

input.tab:checked + .tab-content

When testing, I also noticed that there was another variation of the 'type' case where base was still not getting set, for the drawer component, so i added a check for that as well.

Both of these seem to be handled properly by the test / demo file now.


Thanks again!
-mike